### PR TITLE
Fix exploit

### DIFF
--- a/lua/badcoderz/server/sv_network.lua
+++ b/lua/badcoderz/server/sv_network.lua
@@ -42,6 +42,8 @@ end)
 
 
 net.Receive("BadCoderz_serverside_file_open",function (len, ply)
+	if not ply:CanUseBadCoderz() then return end
+		
 	local gamePath = net.ReadString()
 	local fakePath = net.ReadString()
 	local line;


### PR DESCRIPTION
Don't allow unauthorised players to download server files.

Without this change it can be used to download an entire server, finding files with MySQL credentials, etc.